### PR TITLE
 ps4-linux-6.15.y - drm: Fix blackscreen at Display Manager and Add 60Hz monitor support

### DIFF
--- a/drivers/gpu/drm/amd/amdgpu/ps4_bridge.c
+++ b/drivers/gpu/drm/amd/amdgpu/ps4_bridge.c
@@ -693,13 +693,22 @@ static const struct drm_display_mode mode_1080p = {
 		 DRM_MODE_FLAG_PHSYNC | DRM_MODE_FLAG_PVSYNC),
 	.picture_aspect_ratio = HDMI_PICTURE_ASPECT_16_9
 };
+/* Having a 120Hz modeline causes incorrect mode selection
+ * by GUI / Display Manager, causing a 60Hz monitor to try
+ * with a 120Hz mode - leading to a blackscreen.
+ * Only fix seems to be having a xorg.conf in /usr/share/X11/xorg.conf.d/
+ *
+ * Disable for now
+ */
 /* 63 - 1920x1080@120Hz */
+/*
 static const struct drm_display_mode mode_1080p120 = {
 	DRM_MODE("1920x1080", DRM_MODE_TYPE_DRIVER, 297000, 1920, 2008,
 			2052, 2200, 0, 1080, 1084, 1089, 1125, 0,
 		   DRM_MODE_FLAG_PHSYNC | DRM_MODE_FLAG_PVSYNC),
 	  .picture_aspect_ratio = HDMI_PICTURE_ASPECT_16_9
 };
+*/
 
 int ps4_bridge_get_modes(struct drm_connector *connector)
 {
@@ -710,8 +719,10 @@ int ps4_bridge_get_modes(struct drm_connector *connector)
 	newmode = drm_mode_duplicate(dev, &mode_1080p);
 	drm_mode_probed_add(connector, newmode);
 
+	/*
 	newmode = drm_mode_duplicate(dev, &mode_1080p120);
 	drm_mode_probed_add(connector, newmode);
+	*/
 
 	//newmode = drm_mode_duplicate(dev, &mode_720p);
 	//drm_mode_probed_add(connector, newmode);
@@ -760,7 +771,10 @@ enum drm_mode_status ps4_bridge_mode_valid(struct drm_connector *connector,
 	int vic = drm_match_cea_mode(mode);
 
 	/* Allow anything that we can match up to a VIC (CEA modes) */
-	if (!vic || (vic != 16 && vic != 4 && vic != 63)) {
+	//if (!vic || (vic != 16 && vic != 4 && vic != 63)) {
+	//Disabled 1920x1080-120Hz for now
+
+	if (!vic || (vic != 16 && vic != 4)) {
 		return MODE_BAD;
 	}
 

--- a/drivers/gpu/drm/amd/amdgpu/ps4_bridge.c
+++ b/drivers/gpu/drm/amd/amdgpu/ps4_bridge.c
@@ -688,7 +688,7 @@ static const struct drm_display_mode mode_720p = {
 };
 /* 16 - 1920x1080@60Hz */
 static const struct drm_display_mode mode_1080p = {
-	DRM_MODE("1920x1080", DRM_MODE_TYPE_DRIVER, 148500, 1920, 2008,
+	DRM_MODE("1920x1080", DRM_MODE_TYPE_DRIVER | DRM_MODE_TYPE_PREFERRED, 148500, 1920, 2008,
 		 2052, 2200, 0, 1080, 1084, 1089, 1125, 0,
 		 DRM_MODE_FLAG_PHSYNC | DRM_MODE_FLAG_PVSYNC),
 	.picture_aspect_ratio = HDMI_PICTURE_ASPECT_16_9
@@ -698,17 +698,15 @@ static const struct drm_display_mode mode_1080p = {
  * with a 120Hz mode - leading to a blackscreen.
  * Only fix seems to be having a xorg.conf in /usr/share/X11/xorg.conf.d/
  *
- * Disable for now
+ * Try setting a TYPE_PREFFERED mode
  */
 /* 63 - 1920x1080@120Hz */
-/*
 static const struct drm_display_mode mode_1080p120 = {
 	DRM_MODE("1920x1080", DRM_MODE_TYPE_DRIVER, 297000, 1920, 2008,
 			2052, 2200, 0, 1080, 1084, 1089, 1125, 0,
 		   DRM_MODE_FLAG_PHSYNC | DRM_MODE_FLAG_PVSYNC),
 	  .picture_aspect_ratio = HDMI_PICTURE_ASPECT_16_9
 };
-*/
 
 int ps4_bridge_get_modes(struct drm_connector *connector)
 {
@@ -719,10 +717,8 @@ int ps4_bridge_get_modes(struct drm_connector *connector)
 	newmode = drm_mode_duplicate(dev, &mode_1080p);
 	drm_mode_probed_add(connector, newmode);
 
-	/*
 	newmode = drm_mode_duplicate(dev, &mode_1080p120);
 	drm_mode_probed_add(connector, newmode);
-	*/
 
 	//newmode = drm_mode_duplicate(dev, &mode_720p);
 	//drm_mode_probed_add(connector, newmode);
@@ -771,13 +767,14 @@ enum drm_mode_status ps4_bridge_mode_valid(struct drm_connector *connector,
 	int vic = drm_match_cea_mode(mode);
 
 	/* Allow anything that we can match up to a VIC (CEA modes) */
-	//if (!vic || (vic != 16 && vic != 4 && vic != 63)) {
-	//Disabled 1920x1080-120Hz for now
+	if (!vic || (vic != 16 && vic != 4 && vic != 63)) {
+	// Might need to disable 63 (1920x1080-120Hz)
 
+	/*
 	if (!vic || (vic != 16 && vic != 4)) {
+	*/
 		return MODE_BAD;
 	}
-
 	return MODE_OK;
 }
 

--- a/drivers/gpu/drm/amd/amdgpu/ps4_bridge.c
+++ b/drivers/gpu/drm/amd/amdgpu/ps4_bridge.c
@@ -1,5 +1,5 @@
 /*
- * Panasonic MN86471A DP->HDMI bridge driver (via PS4 Aeolia ICC interface)
+ * Panasonic MN86471A / MN864729 DP->HDMI bridge driver (via PS4 Aeolia ICC interface)
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -15,6 +15,20 @@
 // TODO (ps4patches): Make functions atomic,
 //  https://lore.kernel.org/linux-arm-kernel/20211020181901.2114645-5-sam@ravnborg.org/
 
+/*
+ * Forward-ported patches from https://github.com/rancido,
+ * 		            in https://github.com/Ps3itaTeam/ps4-linux/
+ * Maybe the problem is no one is putting a "Copyright"
+ * in their files ... We don't know who introduced what change or where,
+ * since there is often no centralized repository.. Patches thrown around
+ * everywhere.
+ * But that goes against the whole nature of tinkery/RE work..?
+ * But does it really? No.
+ *
+ *
+ * Copyright: .....
+ *
+*/
 #include <asm/ps4.h>
 
 #include <drm/drm_crtc.h>
@@ -247,7 +261,7 @@ static void cq_mask(struct i2c_cmdqueue *q, u16 addr, u8 value, u8 mask)
 	*q->p++ = mask;
 }
 
-#if 1
+#if 0
 static void cq_delay(struct i2c_cmdqueue *q, u16 time)
 {
 	cq_cmd(q, CMD_DELAY);
@@ -524,9 +538,12 @@ static void ps4_bridge_enable(struct drm_bridge *bridge)
 		cq_mask(&mn_bridge->cq, 0x1e00, 0x00, 0x21);
 		cq_mask(&mn_bridge->cq, 0x1e02, 0x00, 0x70);
 		// 03 08 01 01 00  2c 01 00
-		cq_delay(&mn_bridge->cq, 0x012c);
+		//rancido has no delay here vvv
+		//cq_delay(&mn_bridge->cq, 0x012c);
 		cq_writereg(&mn_bridge->cq, 0x6020, 0x00);
-		cq_delay(&mn_bridge->cq, 0x0032);
+
+		//rancido has no delay here vvv
+		//cq_delay(&mn_bridge->cq, 0x0032);
 		cq_writereg(&mn_bridge->cq, 0x7402, 0x1c);
 		cq_writereg(&mn_bridge->cq, 0x6020, 0x04);
 		cq_writereg(&mn_bridge->cq, TSYSCTRL, TSYSCTRL_HDMI);
@@ -569,7 +586,8 @@ static void ps4_bridge_enable(struct drm_bridge *bridge)
 		cq_wait_set(&mn_bridge->cq, 0x10f6, 0x80);
 		cq_mask(&mn_bridge->cq, 0x7226, 0x00, 0x80);
 		cq_mask(&mn_bridge->cq, 0x7228, 0x00, 0xFF);
-		cq_delay(&mn_bridge->cq, 0x012c);
+		// rancido has no delay here vvv
+		//cq_delay(&mn_bridge->cq, 0x012c);
 		cq_writereg(&mn_bridge->cq, 0x7204, 0x40);
 		cq_wait_clear(&mn_bridge->cq, 0x7204, 0x40);
 		cq_writereg(&mn_bridge->cq, 0x7a8b, 0x05);
@@ -780,7 +798,11 @@ int ps4_bridge_register(struct drm_connector *connector,
 	// TODO (ps4patches): This seems to be the new way of adding bridges
 	drm_bridge_add(&mn_bridge->bridge);
 
-	ret = drm_bridge_attach(mn_bridge->encoder, &mn_bridge->bridge, NULL, DRM_BRIDGE_ATTACH_NO_CONNECTOR);
+	//ret = drm_bridge_attach(mn_bridge->encoder, &mn_bridge->bridge, NULL, DRM_BRIDGE_ATTACH_NO_CONNECTOR);
+
+	// Allow the bridge to create its own connectors with last parameter = 0.
+	// There seemms to be a blackscreen when this is NO_CONNECTOR :
+	ret = drm_bridge_attach(mn_bridge->encoder, &mn_bridge->bridge, NULL, 0);
 	if (ret) {
 		DRM_ERROR("Failed to initialize bridge with drm\n");
 		return -EINVAL;


### PR DESCRIPTION
Fixes: 
- https://github.com/crashniels/linux/issues/14
by
https://github.com/crashniels/linux/commit/f60fdf6cc540437ba08337b40f57a7d6521cb785
Should fix the blackscreen that occurs when going from kernel
    and initramfs to a distro's graphical display manager.
    Makes the switch / refresh to a new mode not cause the blackscreen.
    
    Fix tested on:
    CUH-1216A (patched on this branch)
    CUH-1215A (different branch)
    CUH-7116B (different branch)

- https://github.com/crashniels/linux/issues/12
by
https://github.com/crashniels/linux/commit/e8925341eb9b5860f82ecf7d542df0dede3cf216
https://github.com/crashniels/linux/commit/a97399eac6a89975501e4a7236b4685f991853cb
Should allow using higher display modes and refresh
    rates (60Hz vs 120Hz) without compromising on support
    for older monitors and lower resolutions.
    
    Fix tested on:
    CUH-1216A (patched on this branch)
    
-- Signed-off-by: feeRnt <81442162+feeRnt@users.noreply.github.com>
